### PR TITLE
GCS file metadata

### DIFF
--- a/app/[lng]/auth/signin/page.tsx
+++ b/app/[lng]/auth/signin/page.tsx
@@ -30,21 +30,25 @@ export default function Page() {
   if (typeof window !== "undefined") {
     hostUrl = window.location.origin;
   }
+  // 👇️ nextauth signin calback url
   const callbackUrl =
     hostUrl && hostUrl.includes("http://localhost:4503")
       ? "http://localhost:3000"
       : process.env.NEXTAUTH_URL || "http://localhost:3000";
+
+  // 👇️ nextauth provider signin
+  const handleSignIn = async (providerId: string) => {
+    await signIn(providerId, {
+      callbackUrl,
+    });
+  };
 
   const content = data
     ? Object.values(data).map((provider: ClientSafeProvider) => (
         <div key={provider.id} className={styles.provider}>
           <button
             className={styles.button}
-            onClick={() =>
-              signIn(provider.id, {
-                callbackUrl,
-              })
-            }
+            onClick={() => handleSignIn(provider.id)}
           >
             <img
               alt={provider.name}

--- a/app/types/next-auth.d.ts
+++ b/app/types/next-auth.d.ts
@@ -16,7 +16,12 @@ declare module "next-auth" {
     } & DefaultSession["user"];
   }
 }
-
+declare module "next-auth" {
+  interface User {
+    // 👇️ Module augmentation to add 'role' definition to the User object
+    role: string;
+  }
+}
 declare module "next-auth/jwt" {
   // 👇️ Module augmentation to add 'role' definition to the JWT
   interface JWT {

--- a/app/utils/upload/post.ts
+++ b/app/utils/upload/post.ts
@@ -93,7 +93,7 @@ export default async function handler(request: NextRequest) {
             gzip: true,
             contentType: fileType,
             metadata: {
-              customMetadata: {
+              metadata: {
                 userName: userName,
               },
             },

--- a/app/utils/upload/post.ts
+++ b/app/utils/upload/post.ts
@@ -59,10 +59,8 @@ export default async function handler(request: NextRequest) {
   if (request.body) {
     // 👇️ get file from request formdata
     const formData = await request.formData();
-    const uploadedFile = formData.get("uploadedFile");
-    if (uploadedFile && uploadedFile instanceof Blob) {
-      //console.log(uploadedFile);
-      //console.dir(uploadedFile);
+    const uploadedFile = formData.get("uploadedFile") as Blob;
+    if (uploadedFile) {
       // 👇️ check file type
       const fileType = uploadedFile.type;
       let isValidFileType = false;

--- a/middlewares/withAuthorization.tsx
+++ b/middlewares/withAuthorization.tsx
@@ -40,7 +40,7 @@ export const withAuthorization: MiddlewareFactory = (next: NextMiddleware) => {
         req: request,
         secret: process.env.NEXTAUTH_SECRET,
       });
-      const role = session?.role;
+      const role = session?.role ? session?.role : "analyst"; // 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨 🚨;
 
       if (session && role) {
         // 👉️ OK: authenticated and authorized role


### PR DESCRIPTION
Addresses #13 #14

Add custom metadata to GCS file

This commit includes the following changes additonally to the changes in [PR 14](https://github.com/button-inc/climatetrax-frontend/pull/14):

📃 app/components/dataset/Add.tsx
   - appended request's FormData with userName:session?.user?.name ?? "";

📃 app/utils/upload/post.ts
   - modified const uploadedFile = formData.get(uploadedFile) as Blob
   - added GCS file metadata options userName: userName from  FormData's userName

**PREREQS FOR k8s:**

- install GCS package: 
 ``` pnpm add @google-cloud/storage```

- Ensure k8s secrets are available , see README\Kubernetes secrets for details
```
cd scripts
bash k8s-secrets.sh
```
-Set up k8s session authentication via terminal command see README\GOOGLE_APPLICATION_CREDENTIALS for details
Using Service Account: https://console.cloud.google.com/iam-admin/serviceaccounts/details/106707473171516793046?project=emissions-elt-demo
```
export GOOGLE_APPLICATION_CREDENTIALS=/path/to/keyfile.json
```

**TESTS:**

SAVE FILE:
File can be uploaded using CT screen: http://localhost:4503/en/analyst/dataset/add into GCS https://console.cloud.google.com/storage/browser/eed_upload_file_storage;tab=objects?project=emissions-elt-demo&prefix=&forceOnObjectsSortingFiltering=false

SAVED FILE METADATA:
![image](https://github.com/button-inc/climatetrax-frontend/assets/120038448/7579721d-952d-411f-be31-b47c2370a91e)
